### PR TITLE
Change package name to gi-streamer

### DIFF
--- a/gi-gstreamer.opam
+++ b/gi-gstreamer.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "gstreamer"
+name: "gi-gstreamer"
 version: "~unknown"
 maintainer: "Manas Jayanth<prometheansacrifice@gmail.com>"
 authors: "Manas Jayanth <prometheansacrifice@gmail.com>"

--- a/lib/dune
+++ b/lib/dune
@@ -15,7 +15,7 @@
           Context.mli Context.ml
           ;; Element_factory.mli Element_factory.ml
           Format.mli Format.ml
-          
+
           ;; Memory.mli Memory.ml
           Map_flags.mli Map_flags.ml
           Meta_info.mli Meta_info.ml
@@ -64,8 +64,8 @@
 
 (library
  (name        Gstreamer)
-  (public_name gstreamer)
-  (libraries ctypes ctypes.foreign gi-glib2 gobject)
+  (public_name gi-gstreamer)
+  (libraries ctypes ctypes.foreign gi-glib2 gi-gobject)
   (c_names         dyn_load_constants_stubs)
   (c_flags         (:include c_flags.sexp))
   (c_library_flags (:include c_library_flags.sexp))


### PR DESCRIPTION
I added the `gi-` prefix for the GLib2 package because user can directly see that it is generated with gobject-introspection. I changed the name of the package for the sake of consistency.