### PR TITLE
Add test suite

### DIFF
--- a/gen/gen.ml
+++ b/gen/gen.ml
@@ -19,9 +19,14 @@ let files_suffix = "Raw"
 (** Instead of generate all the data structures (and theirs related methods or
  *  constants), the idea is to choose what is needed. *)
 let data_structures =
-  [ "Allocator"; "AllocationParams"; "BufferList"; "BufferingMode"; "URIType"; "PadTemplate"; "State"; "StateChangeReturn"; "Clock"; "Context"; "Sample"; "Segment"; "SegmentFlags"; "Stream"; "StreamFlags"; "StreamType"; "StreamCollection";  "TagMergeMode"; "TagScope"; "TocEntryType"; "Format"; "MetaInfo"; "Meta"; "Rank"; "Bin"; "ElementFlags"; "Iterator"; "IteratorResult"; "ProtectionMeta" ]
+  [ "Allocator"; "AllocationParams"; "BufferList"; "BufferingMode"; "URIType";
+    "PadTemplate"; "State"; "StateChangeReturn"; "Clock"; "Context"; "Sample";
+    "Segment"; "SegmentFlags"; "Stream"; "StreamFlags"; "StreamType";
+    "StreamCollection"; "TagMergeMode"; "TagScope"; "TocEntryType"; "Format";
+    "MetaInfo"; "Meta"; "Rank"; "Bin"; "ElementFlags"; "Iterator";
+    "IteratorResult"; "ProtectionMeta" ]
 (*  "Toc"; "Device"; "Buffer"; "Element"; "Structure"; "MiniObject"; "Caps"; "TagList";"Message"; "BufferPool"; "TocEntry"; "Memory"; "MapInfo"; "ElementFactory"; "ParentBufferMeta"; "Bus";  *)
-  
+
 (** One can choose to skip the bindings of some constants because they are not
  *  needed or because you want to create manually the bindings in the "Core.ml"
  *  file. *)
@@ -29,7 +34,7 @@ let const_to_skip = ["MAJOR_VERSION"; "MINOR_VERSION"; "MICRO_VERSION"]
 
 (** Like for the data_structures, you have to choose with function should have
  *  its bindings generated. *)
-let functions = ["init"]
+let functions = ["is_initialized"]
 
 let sources = Loader.generate_files ("Core" ^ files_suffix)
 

--- a/lib/Core.ml
+++ b/lib/Core.ml
@@ -1,1 +1,3 @@
+include Core_raw
+
 external init: int option -> string array option -> unit = "caml_gst_init"

--- a/lib/dune
+++ b/lib/dune
@@ -53,7 +53,8 @@
           Stream_type.mli Stream_type.ml
           Stream_flags.mli Stream_flags.ml
           ;; Structure.mli Structure.ml
-          Lock_flags.mli Lock_flags.ml)
+          Lock_flags.mli Lock_flags.ml
+	  Core_raw.ml Core_raw.mli)
  (deps    ../gen/gen.exe)
  (action  (run %{deps} -o %{targets})))
 

--- a/tests/Test_core.ml
+++ b/tests/Test_core.ml
@@ -1,0 +1,14 @@
+open OUnit2
+open Gstreamer
+
+let test_gstreamer_initialization _ctxt =
+  let () = Gstreamer.Core.init None None in
+  let state = Gstreamer.Core.is_initialized () in
+  let message = "Gstreamer should be detecter as initialized" in
+  assert_bool message state
+
+let tests =
+  "Gstreamer Core tests" >:::
+  [
+    "Gstreamer initialization" >:: test_gstreamer_initialization;
+  ]

--- a/tests/dune
+++ b/tests/dune
@@ -1,0 +1,9 @@
+(executables
+  (names tests)
+  (libraries   gi-glib2 gi-gstreamer oUnit)
+)
+
+(alias
+  (name    runtest)
+  (deps    (:x tests.exe))
+  (action  (run %{x})))

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -1,0 +1,9 @@
+open OUnit2
+
+let () =
+  run_test_tt_main
+  ("GStreamer tests" >:::
+    [
+      Test_core.tests;
+    ]
+  )


### PR DESCRIPTION
in the `gen/gen.ml` file, given that you created C bindings for `gst_binding`, you don't need to add it in `let functions = ["init"]`. 

Furthermore, all the functions declared and the constants as well, will be binded in the module `Core_raw`, defined in the files `_build/default/lib/Core_raw.ml` and `_build/default/lib/Core_raw.mli`. 

And for this file to be included, it is mandatory to add them in the `lib/dune` file like I did in this commit.

Now I guess we can use the tests with travis to do CI.